### PR TITLE
Prevented click on context menu while not showing

### DIFF
--- a/src/UI/Elements/Menus/PopupMenu.cpp
+++ b/src/UI/Elements/Menus/PopupMenu.cpp
@@ -25,6 +25,8 @@ void PopupMenu::display()
 MenuInterface* PopupMenu::containsPoint(sf::Vector2f pointCoords)
 {
     sf::Vector2f position = this->getPosition();
+    if(!this->do_display)
+        return nullptr;
     return (position.y < pointCoords.y
         && position.y + this->buttons.size() * Constants::PopupMenu::Button::Height > pointCoords.y
         && position.x < pointCoords.x


### PR DESCRIPTION
## Changes
- Added a conditional statement to check whether context menu is showing or not before processing event.

## Issues:
- Solve #2.
